### PR TITLE
Restructuring of LLVM related classes into separate packages

### DIFF
--- a/Smalltalk/ASTSmalltalk-LLVM-Tests/ASLLVMOutputTest.class.st
+++ b/Smalltalk/ASTSmalltalk-LLVM-Tests/ASLLVMOutputTest.class.st
@@ -4,9 +4,8 @@ Class {
 	#instVars : [
 		'output'
 	],
-	#category : 'ASTSmalltalk-Tests-Tests',
-	#package : 'ASTSmalltalk-Tests',
-	#tag : 'Tests'
+	#category : 'ASTSmalltalk-LLVM-Tests',
+	#package : 'ASTSmalltalk-LLVM-Tests'
 }
 
 { #category : 'running' }

--- a/Smalltalk/ASTSmalltalk-LLVM-Tests/ASLLVMTest.class.st
+++ b/Smalltalk/ASTSmalltalk-LLVM-Tests/ASLLVMTest.class.st
@@ -1,9 +1,8 @@
 Class {
 	#name : 'ASLLVMTest',
 	#superclass : 'ASCodeTest',
-	#category : 'ASTSmalltalk-Tests-Tests',
-	#package : 'ASTSmalltalk-Tests',
-	#tag : 'Tests'
+	#category : 'ASTSmalltalk-LLVM-Tests',
+	#package : 'ASTSmalltalk-LLVM-Tests'
 }
 
 { #category : 'running' }

--- a/Smalltalk/ASTSmalltalk-LLVM-Tests/AStackFlowTest.class.st
+++ b/Smalltalk/ASTSmalltalk-LLVM-Tests/AStackFlowTest.class.st
@@ -11,9 +11,8 @@ Class {
 		'flowNew1',
 		'flowNew2'
 	],
-	#category : 'ASTSmalltalk-Tests-Tests',
-	#package : 'ASTSmalltalk-Tests',
-	#tag : 'Tests'
+	#category : 'ASTSmalltalk-LLVM-Tests',
+	#package : 'ASTSmalltalk-LLVM-Tests'
 }
 
 { #category : 'running' }

--- a/Smalltalk/ASTSmalltalk-LLVM-Tests/package.st
+++ b/Smalltalk/ASTSmalltalk-LLVM-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'ASTSmalltalk-LLVM-Tests' }

--- a/Smalltalk/ASTSmalltalk-LLVM/ASImageLLVMOutput.class.st
+++ b/Smalltalk/ASTSmalltalk-LLVM/ASImageLLVMOutput.class.st
@@ -4,9 +4,8 @@ Class {
 	#instVars : [
 		'coder'
 	],
-	#category : 'ASTSmalltalk-Output',
-	#package : 'ASTSmalltalk',
-	#tag : 'Output'
+	#category : 'ASTSmalltalk-LLVM',
+	#package : 'ASTSmalltalk-LLVM'
 }
 
 { #category : 'API' }

--- a/Smalltalk/ASTSmalltalk-LLVM/ASLLBlockOutput.class.st
+++ b/Smalltalk/ASTSmalltalk-LLVM/ASLLBlockOutput.class.st
@@ -8,9 +8,8 @@ Class {
 		'methodGenerator',
 		'block'
 	],
-	#category : 'ASTSmalltalk-Output',
-	#package : 'ASTSmalltalk',
-	#tag : 'Output'
+	#category : 'ASTSmalltalk-LLVM',
+	#package : 'ASTSmalltalk-LLVM'
 }
 
 { #category : 'accessing' }

--- a/Smalltalk/ASTSmalltalk-LLVM/ASLLFileContext.class.st
+++ b/Smalltalk/ASTSmalltalk-LLVM/ASLLFileContext.class.st
@@ -9,9 +9,8 @@ Class {
 	#instVars : [
 		'converter'
 	],
-	#category : 'ASTSmalltalk-Output',
-	#package : 'ASTSmalltalk',
-	#tag : 'Output'
+	#category : 'ASTSmalltalk-LLVM',
+	#package : 'ASTSmalltalk-LLVM'
 }
 
 { #category : 'initialization' }

--- a/Smalltalk/ASTSmalltalk-LLVM/ASLLMethodOutput.class.st
+++ b/Smalltalk/ASTSmalltalk-LLVM/ASLLMethodOutput.class.st
@@ -15,9 +15,8 @@ Class {
 		'NilName',
 		'TypeMap'
 	],
-	#category : 'ASTSmalltalk-Output',
-	#package : 'ASTSmalltalk',
-	#tag : 'Output'
+	#category : 'ASTSmalltalk-LLVM',
+	#package : 'ASTSmalltalk-LLVM'
 }
 
 { #category : 'compiling' }

--- a/Smalltalk/ASTSmalltalk-LLVM/ASLLOutput.class.st
+++ b/Smalltalk/ASTSmalltalk-LLVM/ASLLOutput.class.st
@@ -4,9 +4,8 @@ I am the generic text outputter for LLVM
 Class {
 	#name : 'ASLLOutput',
 	#superclass : 'ASTextOutput',
-	#category : 'ASTSmalltalk-Output',
-	#package : 'ASTSmalltalk',
-	#tag : 'Output'
+	#category : 'ASTSmalltalk-LLVM',
+	#package : 'ASTSmalltalk-LLVM'
 }
 
 { #category : 'accessing' }

--- a/Smalltalk/ASTSmalltalk-LLVM/package.st
+++ b/Smalltalk/ASTSmalltalk-LLVM/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'ASTSmalltalk-LLVM' }


### PR DESCRIPTION
Structurally separte, not fully standalone. 
`addflow` functions are defined within separate basic blocks (need to search for a way to separate that functionality in the future) 
Initial structure for now