### PR TITLE
Remove 'Benchmarks' package from baseline

### DIFF
--- a/Smalltalk/BaselineOfZagSmalltalk/BaselineOfZagSmalltalk.class.st
+++ b/Smalltalk/BaselineOfZagSmalltalk/BaselineOfZagSmalltalk.class.st
@@ -48,7 +48,6 @@ BaselineOfZagSmalltalk >> baseline: spec [
 			package: 'Zag-Output-Tests' with: [
 				spec requires: #( 'Zag-Output' 'Zag-Compiler-Tests'
 					   'Zag-Core' ) ];
-			package: 'Benchmarks' with: [ spec requires: #( 'Zag-Core' ) ];
 			package: 'Zag-Library' ]
 ]
 


### PR DESCRIPTION
This package does not exist anywhere in the source code, and having it prevents Zag-Smalltalk from loading properly.  This should fix issue #116.