### PR TITLE
Add conversion from Zag AST to Pharo AST

### DIFF
--- a/Smalltalk/Zag-Core/ASArray.class.st
+++ b/Smalltalk/Zag-Core/ASArray.class.st
@@ -23,6 +23,11 @@ ASArray >> = other [
 			  self statements = other statements ]
 ]
 
+{ #category : 'converting' }
+ASArray >> asPharoAST [
+	self error: 'ASArray seems to be missing instance variables!'.
+]
+
 { #category : 'printing' }
 ASArray >> do: aBlock [
 	1 to: self size do: [ : idx| aBlock value: (self at: idx) ]

--- a/Smalltalk/Zag-Core/ASAssign.class.st
+++ b/Smalltalk/Zag-Core/ASAssign.class.st
@@ -24,6 +24,11 @@ ASAssign >> = other [
 	^ self class = other class and: [ self variable = other variable and: [ self expression = other expression ] ]
 ]
 
+{ #category : 'converting' }
+ASAssign >> asPharoAST [
+	^OCAssignmentNode variable: variable asPharoAST value: expression asPharoAST.
+]
+
 { #category : 'accessing' }
 ASAssign >> blocks [
 	^expression blocks

--- a/Smalltalk/Zag-Core/ASBlockNode.class.st
+++ b/Smalltalk/Zag-Core/ASBlockNode.class.st
@@ -17,6 +17,13 @@ ASBlockNode class >> arguments: args locals: locals body: body [
 	^ (self locals: locals body: body) arguments: args
 ]
 
+{ #category : 'converting' }
+ASBlockNode >> asPharoAST [
+	| pharoBody |
+	pharoBody := OCSequenceNode temporaries: (locals collect: #asPharoAST) statements: (body collect: #asPharoAST).
+	^OCBlockNode arguments: (arguments collect: #asPharoAST) body: pharoBody.
+]
+
 { #category : 'accessing' }
 ASBlockNode >> blocks [
 

--- a/Smalltalk/Zag-Core/ASCascade.class.st
+++ b/Smalltalk/Zag-Core/ASCascade.class.st
@@ -26,6 +26,13 @@ ASCascade >> = other [
 			  self sends = other sends ] ]
 ]
 
+{ #category : 'converting' }
+ASCascade >> asPharoAST [
+	| pharoSends |
+	pharoSends := sends collect: [ :send | send target: target; asPharoAST ].
+	OCCascadeNode messages: pharoSends.
+]
+
 { #category : 'accessing' }
 ASCascade >> children [
 	| c |

--- a/Smalltalk/Zag-Core/ASCascade.class.st
+++ b/Smalltalk/Zag-Core/ASCascade.class.st
@@ -30,7 +30,7 @@ ASCascade >> = other [
 ASCascade >> asPharoAST [
 	| pharoSends |
 	pharoSends := sends collect: [ :send | send target: target; asPharoAST ].
-	OCCascadeNode messages: pharoSends.
+	^OCCascadeNode messages: pharoSends.
 ]
 
 { #category : 'accessing' }

--- a/Smalltalk/Zag-Core/ASClassNode.class.st
+++ b/Smalltalk/Zag-Core/ASClassNode.class.st
@@ -27,6 +27,12 @@ ASClassNode >> addMethod: anASMethodNode [
 	methods at: anASMethodNode selector put: anASMethodNode
 ]
 
+{ #category : 'converting' }
+ASClassNode >> asPharoAST [
+	"Converts me to the associated Pharo AST."
+	self error: 'Pharo AST doesn''t have any form of class node.'
+]
+
 { #category : 'initialization' }
 ASClassNode >> from: aClass [
 

--- a/Smalltalk/Zag-Core/ASLiteral.class.st
+++ b/Smalltalk/Zag-Core/ASLiteral.class.st
@@ -29,6 +29,11 @@ ASLiteral >> accept: aVisitor [
 	^ aVisitor visitLiteral: literal
 ]
 
+{ #category : 'converting' }
+ASLiteral >> asPharoAST [
+	^OCLiteralNode value: literal.
+]
+
 { #category : 'accessing' }
 ASLiteral >> inferType: aClass [
 

--- a/Smalltalk/Zag-Core/ASMethodNode.class.st
+++ b/Smalltalk/Zag-Core/ASMethodNode.class.st
@@ -67,7 +67,7 @@ ASMethodNode >> accept: aVisitor [
 ASMethodNode >> asPharoAST [
 	| pharoBody |
 	pharoBody := OCSequenceNode temporaries: (locals collect: #asPharoAST) statements: (body collect: #asPharoAST).
-	^OCMethodNode selector: (OCSelectorNode value: selector asString) arguments: (arguments collect: #asPharoAST) body: pharoBody.
+	^OCMethodNode selector: selector arguments: (arguments collect: #asPharoAST) body: pharoBody.
 ]
 
 { #category : 'accessing' }

--- a/Smalltalk/Zag-Core/ASMethodNode.class.st
+++ b/Smalltalk/Zag-Core/ASMethodNode.class.st
@@ -63,6 +63,13 @@ ASMethodNode >> accept: aVisitor [
 	^ aVisitor visitMethod: self
 ]
 
+{ #category : 'converting' }
+ASMethodNode >> asPharoAST [
+	| pharoBody |
+	pharoBody := OCSequenceNode temporaries: (locals collect: #asPharoAST) statements: (body collect: #asPharoAST).
+	^OCMethodNode selector: (OCSelectorNode value: selector asString) arguments: (arguments collect: #asPharoAST) body: pharoBody.
+]
+
 { #category : 'accessing' }
 ASMethodNode >> children [
 

--- a/Smalltalk/Zag-Core/ASPragma.class.st
+++ b/Smalltalk/Zag-Core/ASPragma.class.st
@@ -27,6 +27,12 @@ ASPragma >> arguments [
 	^ args
 ]
 
+{ #category : 'converting' }
+ASPragma >> asPharoAST [
+	"Warning: ASPragma seems to be missing the selector that OCPragmaNode wants."
+	^OCPragmaNode selector: nil arguments: (args collect: #asPharoAST).
+]
+
 { #category : 'printing' }
 ASPragma >> inspectZagASTOn: aStream [
 	super inspectZagASTOn: aStream.

--- a/Smalltalk/Zag-Core/ASRef.class.st
+++ b/Smalltalk/Zag-Core/ASRef.class.st
@@ -23,6 +23,11 @@ ASRef >> = other [
 	^ self class = other class and: [ self variable = other variable ]
 ]
 
+{ #category : 'converting' }
+ASRef >> asPharoAST [
+	^OCVariableNode named: variable.
+]
+
 { #category : 'printing' }
 ASRef >> inspectZagASTOn: aStream [
 	super inspectZagASTOn: aStream.

--- a/Smalltalk/Zag-Core/ASReturn.class.st
+++ b/Smalltalk/Zag-Core/ASReturn.class.st
@@ -29,6 +29,11 @@ ASReturn >> accept: aVisitor [
 	^ aVisitor visitReturn: self
 ]
 
+{ #category : 'converting' }
+ASReturn >> asPharoAST [
+	^OCReturnNode value: expression asPharoAST.
+]
+
 { #category : 'accessing' }
 ASReturn >> blocks [
 	^expression blocks

--- a/Smalltalk/Zag-Core/ASSend.class.st
+++ b/Smalltalk/Zag-Core/ASSend.class.st
@@ -52,7 +52,9 @@ ASSend >> args [
 
 { #category : 'converting' }
 ASSend >> asPharoAST [
-	^OCMessageNode receiver: target asPharoAST selector: selector arguments: (args collect: #asPharoAST) 
+	| pharoArgs |
+	pharoArgs := args ifNil: [ #() ] ifNotNil: [ args collect: #asPharoAST ].
+	^OCMessageNode receiver: target asPharoAST selector: selector arguments: pharoArgs.
 ]
 
 { #category : 'accessing' }

--- a/Smalltalk/Zag-Core/ASSend.class.st
+++ b/Smalltalk/Zag-Core/ASSend.class.st
@@ -50,6 +50,11 @@ ASSend >> args [
 	^ args
 ]
 
+{ #category : 'converting' }
+ASSend >> asPharoAST [
+	^OCMessageNode receiver: target asPharoAST selector: selector arguments: (args collect: #asPharoAST) 
+]
+
 { #category : 'accessing' }
 ASSend >> blocks [
 

--- a/Smalltalk/Zag-Core/AST.class.st
+++ b/Smalltalk/Zag-Core/AST.class.st
@@ -25,6 +25,12 @@ AST >> accept: aVisitor [
 AST >> asAST [
 ]
 
+{ #category : 'converting' }
+AST >> asPharoAST [
+	"Converts me to the associated Pharo AST."
+	self subclassResponsibility.
+]
+
 { #category : 'printing' }
 AST >> printOn: aStream [
 

--- a/Smalltalk/Zag-Core/ASThisContext.class.st
+++ b/Smalltalk/Zag-Core/ASThisContext.class.st
@@ -9,6 +9,11 @@ Class {
 	#tag : 'AST'
 }
 
+{ #category : 'converting' }
+ASThisContext >> asPharoAST [
+	^OCVariableNode thisContextNode.
+]
+
 { #category : 'compiling' }
 ASThisContext >> zigWalk: aGenerator [
 

--- a/Smalltalk/Zag-Core/ASThisProcess.class.st
+++ b/Smalltalk/Zag-Core/ASThisProcess.class.st
@@ -9,6 +9,11 @@ Class {
 	#tag : 'AST'
 }
 
+{ #category : 'converting' }
+ASThisProcess >> asPharoAST [
+	^OCVariableNode thisProcessNode.
+]
+
 { #category : 'compiling' }
 ASThisProcess >> zigWalk: aGenerator [
 


### PR DESCRIPTION
This adds a `asPharoAST` message that converts the Zag AST to the Pharo AST.  Implemented for all subclasses of `AST`, except those mentioned below:
- ASClassNode has no equivalent in Pharo.
- ASPragma does not have enough information (selector missing).
- ASArray does not have any instance variables.