### PR TITLE
Add shortcut to run code as Pharo

### DIFF
--- a/Smalltalk/Zag-Core/AST.class.st
+++ b/Smalltalk/Zag-Core/AST.class.st
@@ -37,3 +37,13 @@ AST >> printOn: aStream [
 	ZagSmalltalk new stream: aStream; visit: self
 	
 ]
+
+{ #category : 'executing' }
+AST >> runAsPharo [
+	"Convert me to a Pharo AST, then run me using the Opal Compiler."
+	| pharoAST compiler |
+	pharoAST := self asPharoAST.
+	compiler := OpalCompiler new.
+	compiler ast: pharoAST.
+	compiler evaluate.
+]


### PR DESCRIPTION
As suggested in the last meeting, I've added a single function that converts code to a Pharo AST then runs it with Opal.  Just do `zagAST runAsPharo`.