### PR TITLE
Improve visitor functionality & fix some problems

### DIFF
--- a/Smalltalk/Zag-Compiler-Tests/ZagSmalltalkTest.class.st
+++ b/Smalltalk/Zag-Compiler-Tests/ZagSmalltalkTest.class.st
@@ -153,10 +153,39 @@ ZagSmalltalkTest >> testPlusStar [
 	^ n1'
 ]
 
-{ #category : 'tests' }
+{ #category : 'tests - printing' }
 ZagSmalltalkTest >> testPrint [
 
-	self assert: 42 asZagLiteral printString equals: '42'
+	self assert: (ASLiteral literal: 42) printString equals: '42'
+]
+
+{ #category : 'tests - printing' }
+ZagSmalltalkTest >> testPrintFToC [
+	"Tests printing a basic F-to-C program."
+	"This is the same F-to-C program used to test ZagPythonConverter."
+	| ast expected |
+	ast := ASMethodNode selector: #main
+			locals: {(ASRef variable: #tempF) . (ASRef variable: #tempC)} body: {
+		ASAssign variable: (ASRef variable: #tempF) expression: (
+			ASSend target: (
+				ASSend target: (ASSend target: (ASRef variable: #UIManager) selector: #default args: #())
+					selector: #request: args: { ASLiteral literal: 'Input temp in F: ' }) selector: #asNumber).
+		ASAssign variable: (ASRef variable: #tempC) expression: (
+			ASSend target: (
+				ASSend target: (ASRef variable: #tempF) selector: #- args: { ASLiteral literal: 32 }
+			) selector: #/ args: { ASLiteral literal: 1.8 }).
+		ASCascade target: (ASRef variable: #Transcript) sends: { 
+			ASSend selector: #show: args: { ASRef variable: #tempC }.
+			ASSend selector: #cr args: #()
+		}
+	}.
+	expected := 'main
+
+	| tempF tempC |
+	tempF := (UIManager default request: ''Input temp in F: '') asNumber.
+	tempC := tempF - 32 / 1.8.
+	Transcript show: tempC; cr'.
+	self assert: ast asString equals: expected.
 ]
 
 { #category : 'tests' }

--- a/Smalltalk/Zag-Compiler/ZagSmalltalk.class.st
+++ b/Smalltalk/Zag-Compiler/ZagSmalltalk.class.st
@@ -105,6 +105,47 @@ ZagSmalltalk >> visit: anAST [
 ]
 
 { #category : 'visiting' }
+ZagSmalltalk >> visitArray: anArray [
+	| isFirst |
+	isFirst := true.
+	stream nextPutAll: '{ '.
+	anArray do: [ :each |
+		isFirst
+			ifTrue: [ isFirst := false ]
+			ifFalse: [ stream nextPutAll: '. ' ].
+		each accept: self.
+	].
+	stream nextPutAll: ' }'.
+]
+
+{ #category : 'visiting' }
+ZagSmalltalk >> visitAssign: anAssign [
+	anAssign variable accept: self.
+	stream nextPutAll: ' := '.
+	anAssign expression accept: self.
+]
+
+{ #category : 'visiting' }
+ZagSmalltalk >> visitBlock: aBlock [
+	^self visitCodeBlock: aBlock
+]
+
+{ #category : 'visiting' }
+ZagSmalltalk >> visitCascade: aCascade [
+	| isFirst |
+	stream nextPut: $(.
+	aCascade target accept: self.
+	stream nextPutAll: ') '.
+	isFirst := true.
+	aCascade sends do: [ :send |
+		isFirst
+			ifTrue: [ isFirst := false ]
+			ifFalse: [ stream nextPutAll: '; ' ].
+		self visitSendArguments: send.
+	]
+]
+
+{ #category : 'visiting' }
 ZagSmalltalk >> visitCodeBlock: aCodeBlock [
 
 	| first |
@@ -117,7 +158,7 @@ ZagSmalltalk >> visitCodeBlock: aCodeBlock [
 				stream nextPutAll: '| '.
 				first := false ]
 			ifFalse: [ stream nextPut: $  ].
-		self visitId: local ].
+		local accept: self ].
 	first ifFalse: [
 			stream nextPutAll: ' |
 ' ].
@@ -173,8 +214,60 @@ ZagSmalltalk >> visitParameter: anASParameter [
 ]
 
 { #category : 'visiting' }
+ZagSmalltalk >> visitRef: aRef [
+	stream nextPutAll: aRef variable
+]
+
+{ #category : 'visiting' }
 ZagSmalltalk >> visitReturn: anASReturn [
 
 	stream nextPutAll: '^ '.
 	anASReturn expression accept: self
+]
+
+{ #category : 'visiting' }
+ZagSmalltalk >> visitSend: aSend [
+	stream nextPut: $(.
+	aSend target accept: self.
+	stream nextPut: $).
+	self visitSendArguments: aSend.
+]
+
+{ #category : 'visiting' }
+ZagSmalltalk >> visitSendArguments: aSend [
+	"Accepts an ASSend and adds its selector/arguments to my stream.  Does NOT print its target."
+	| selectorString |
+	selectorString := aSend selector asString.
+	(selectorString includes: $:)
+		ifTrue: [ self visitSendArgumentsKeyword: aSend ]
+		ifFalse: [ (selectorString allSatisfy: #isSpecial)
+			ifTrue: [ self visitSendArgumentsBinary: aSend ]
+			ifFalse: [ self visitSendArgumentsUnary: aSend ]].
+]
+
+{ #category : 'visiting' }
+ZagSmalltalk >> visitSendArgumentsBinary: aSend [
+	"visitSendArguments:, where the ASSend is unary."
+	stream nextPut: Character space; nextPutAll: aSend selector; nextPutAll: ' ('.
+	aSend args first accept: self.
+	stream nextPut: $).
+]
+
+{ #category : 'visiting' }
+ZagSmalltalk >> visitSendArgumentsKeyword: aSend [
+	"Accepts an ASSend and adds its selector/arguments to my stream.  Does NOT print its target."
+	| sendParts |
+	sendParts := (aSend selector asString splitOn: ':') allButLast.
+	sendParts size = aSend args size ifFalse: [ self error: 'ASSend has wrong number of arguments.' ].
+	1 to: sendParts size do: [ :i |
+		stream nextPut: Character space; nextPutAll: (sendParts at: i); nextPutAll: ': ('.
+		(aSend args at: i) accept: self.
+		stream nextPut: $).
+	]
+]
+
+{ #category : 'visiting' }
+ZagSmalltalk >> visitSendArgumentsUnary: aSend [
+	"visitSendArguments:, where the ASSend is unary."
+	stream nextPut: Character space; nextPutAll: aSend selector.
 ]

--- a/Smalltalk/Zag-Compiler/ZagSmalltalk.class.st
+++ b/Smalltalk/Zag-Compiler/ZagSmalltalk.class.st
@@ -138,9 +138,9 @@ ZagSmalltalk >> visitId: anId [
 ]
 
 { #category : 'visiting' }
-ZagSmalltalk >> visitLiteral: anObject [
+ZagSmalltalk >> visitLiteral: aLiteral [
 
-	stream print: anObject
+	stream print: aLiteral literal
 ]
 
 { #category : 'visiting' }

--- a/Smalltalk/Zag-Compiler/ZagSmalltalk.class.st
+++ b/Smalltalk/Zag-Compiler/ZagSmalltalk.class.st
@@ -146,7 +146,7 @@ ZagSmalltalk >> visitCascade: aCascade [
 	aCascade sends do: [ :send |
 		isFirst
 			ifTrue: [ isFirst := false ]
-			ifFalse: [ stream nextPutAll: '; ' ].
+			ifFalse: [ stream nextPut: $; ].
 		self visitSendArguments: send.
 	]
 ]

--- a/Smalltalk/Zag-Compiler/ZagSmalltalk.class.st
+++ b/Smalltalk/Zag-Compiler/ZagSmalltalk.class.st
@@ -105,6 +105,14 @@ ZagSmalltalk >> visit: anAST [
 ]
 
 { #category : 'visiting' }
+ZagSmalltalk >> visit: anObject withSurroundingBrackets: bracketsEnabled [
+	"Visits anObject.  If bracketsEnabled, print brackets around it."
+	bracketsEnabled ifTrue: [ stream nextPut: $( ].
+	anObject accept: self.
+	bracketsEnabled ifTrue: [ stream nextPut: $) ].
+]
+
+{ #category : 'visiting' }
 ZagSmalltalk >> visitArray: anArray [
 	| isFirst |
 	isFirst := true.
@@ -133,9 +141,7 @@ ZagSmalltalk >> visitBlock: aBlock [
 { #category : 'visiting' }
 ZagSmalltalk >> visitCascade: aCascade [
 	| isFirst |
-	stream nextPut: $(.
-	aCascade target accept: self.
-	stream nextPutAll: ') '.
+	self visitSendTarget: aCascade.
 	isFirst := true.
 	aCascade sends do: [ :send |
 		isFirst
@@ -227,30 +233,25 @@ ZagSmalltalk >> visitReturn: anASReturn [
 
 { #category : 'visiting' }
 ZagSmalltalk >> visitSend: aSend [
-	stream nextPut: $(.
-	aSend target accept: self.
-	stream nextPut: $).
-	self visitSendArguments: aSend.
+	self visitSendTarget: aSend; visitSendArguments: aSend.
 ]
 
 { #category : 'visiting' }
 ZagSmalltalk >> visitSendArguments: aSend [
 	"Accepts an ASSend and adds its selector/arguments to my stream.  Does NOT print its target."
-	| selectorString |
-	selectorString := aSend selector asString.
-	(selectorString includes: $:)
-		ifTrue: [ self visitSendArgumentsKeyword: aSend ]
-		ifFalse: [ (selectorString allSatisfy: #isSpecial)
-			ifTrue: [ self visitSendArgumentsBinary: aSend ]
-			ifFalse: [ self visitSendArgumentsUnary: aSend ]].
+	aSend 
+		ifUnary: [ self visitSendArgumentsUnary: aSend ]
+		ifBinary: [ self visitSendArgumentsBinary: aSend ]
+		ifKeyword: [ self visitSendArgumentsKeyword: aSend ].
 ]
 
 { #category : 'visiting' }
 ZagSmalltalk >> visitSendArgumentsBinary: aSend [
 	"visitSendArguments:, where the ASSend is unary."
-	stream nextPut: Character space; nextPutAll: aSend selector; nextPutAll: ' ('.
+	stream nextPut: Character space; nextPutAll: aSend selector; nextPut: Character space.
+	(aSend argNeedsBrackets: aSend args first) ifTrue: [ stream nextPut: $( ].
 	aSend args first accept: self.
-	stream nextPut: $).
+	(aSend argNeedsBrackets: aSend args first) ifTrue: [ stream nextPut: $) ].
 ]
 
 { #category : 'visiting' }
@@ -260,9 +261,10 @@ ZagSmalltalk >> visitSendArgumentsKeyword: aSend [
 	sendParts := (aSend selector asString splitOn: ':') allButLast.
 	sendParts size = aSend args size ifFalse: [ self error: 'ASSend has wrong number of arguments.' ].
 	1 to: sendParts size do: [ :i |
-		stream nextPut: Character space; nextPutAll: (sendParts at: i); nextPutAll: ': ('.
+		stream nextPut: Character space; nextPutAll: (sendParts at: i); nextPutAll: ': '.
+		(aSend argNeedsBrackets: (aSend args at: i)) ifTrue: [ stream nextPut: $( ].
 		(aSend args at: i) accept: self.
-		stream nextPut: $).
+		(aSend argNeedsBrackets: (aSend args at: i)) ifTrue: [ stream nextPut: $) ].
 	]
 ]
 
@@ -270,4 +272,12 @@ ZagSmalltalk >> visitSendArgumentsKeyword: aSend [
 ZagSmalltalk >> visitSendArgumentsUnary: aSend [
 	"visitSendArguments:, where the ASSend is unary."
 	stream nextPut: Character space; nextPutAll: aSend selector.
+]
+
+{ #category : 'visiting' }
+ZagSmalltalk >> visitSendTarget: aSend [
+	"Prints the target of an ASSend or ASCascade."
+	aSend targetNeedsBrackets ifTrue: [ stream nextPut: $( ].
+	aSend target accept: self.
+	aSend targetNeedsBrackets ifTrue: [ stream nextPut: $) ].
 ]

--- a/Smalltalk/Zag-Core/ASArray.class.st
+++ b/Smalltalk/Zag-Core/ASArray.class.st
@@ -23,6 +23,11 @@ ASArray >> = other [
 			  self statements = other statements ]
 ]
 
+{ #category : 'visiting' }
+ASArray >> accept: aVisitor [
+	^aVisitor visitArray: self
+]
+
 { #category : 'converting' }
 ASArray >> asPharoAST [
 	self error: 'ASArray seems to be missing instance variables!'.

--- a/Smalltalk/Zag-Core/ASArray.class.st
+++ b/Smalltalk/Zag-Core/ASArray.class.st
@@ -49,6 +49,12 @@ ASArray >> fillFrom: aCollection with: aBlock [
 		self at: (index := index + 1) put: (aBlock value: each) ]
 ]
 
+{ #category : 'accessing' }
+ASArray >> statements [
+	"Returns a list containing all my statements."
+	^(1 to: self size) collect: [ :i | self at: i ]
+]
+
 { #category : 'compiling' }
 ASArray >> zigWalk: aGenerator [
 

--- a/Smalltalk/Zag-Core/ASAssign.class.st
+++ b/Smalltalk/Zag-Core/ASAssign.class.st
@@ -24,6 +24,11 @@ ASAssign >> = other [
 	^ self class = other class and: [ self variable = other variable and: [ self expression = other expression ] ]
 ]
 
+{ #category : 'visiting' }
+ASAssign >> accept: aVisitor [
+	^aVisitor visitAssign: self
+]
+
 { #category : 'converting' }
 ASAssign >> asPharoAST [
 	^OCAssignmentNode variable: variable asPharoAST value: expression asPharoAST.

--- a/Smalltalk/Zag-Core/ASBlockNode.class.st
+++ b/Smalltalk/Zag-Core/ASBlockNode.class.st
@@ -17,6 +17,11 @@ ASBlockNode class >> arguments: args locals: locals body: body [
 	^ (self locals: locals body: body) arguments: args
 ]
 
+{ #category : 'visiting' }
+ASBlockNode >> accept: aVisitor [
+	^aVisitor visitBlock: self
+]
+
 { #category : 'converting' }
 ASBlockNode >> asPharoAST [
 	| pharoBody |

--- a/Smalltalk/Zag-Core/ASCascade.class.st
+++ b/Smalltalk/Zag-Core/ASCascade.class.st
@@ -26,6 +26,11 @@ ASCascade >> = other [
 			  self sends = other sends ] ]
 ]
 
+{ #category : 'visiting' }
+ASCascade >> accept: aVisitor [
+	^aVisitor visitCascade: self
+]
+
 { #category : 'converting' }
 ASCascade >> asPharoAST [
 	| pharoSends |

--- a/Smalltalk/Zag-Core/ASCascade.class.st
+++ b/Smalltalk/Zag-Core/ASCascade.class.st
@@ -77,6 +77,13 @@ ASCascade >> target: expression [
 ]
 
 { #category : 'compiling' }
+ASCascade >> targetNeedsBrackets [
+	"Returns whether or not my target needs brackets."
+	^(ASSend target: self target selector: self sends first selector args: self sends first args)
+		targetNeedsBrackets
+]
+
+{ #category : 'compiling' }
 ASCascade >> zigWalk: aGenerator [
 | size |
 	size := sends size.

--- a/Smalltalk/Zag-Core/ASClassNode.class.st
+++ b/Smalltalk/Zag-Core/ASClassNode.class.st
@@ -21,6 +21,11 @@ ASClassNode >> = other [
 	^ name = other name
 ]
 
+{ #category : 'visiting' }
+ASClassNode >> accept: aVisitor [
+	^aVisitor visitClass: self
+]
+
 { #category : 'adding' }
 ASClassNode >> addMethod: anASMethodNode [ 
 

--- a/Smalltalk/Zag-Core/ASCodeBlock.class.st
+++ b/Smalltalk/Zag-Core/ASCodeBlock.class.st
@@ -94,7 +94,7 @@ ASCodeBlock >> inspectZagASTOn: aStream [
 		aStream << #|.
 		aStream space.
 		locals do: [ :local |
-			aStream << local.
+			aStream << local asString.
 			aStream space ].
 		aStream << #| ].
 

--- a/Smalltalk/Zag-Core/ASLiteral.class.st
+++ b/Smalltalk/Zag-Core/ASLiteral.class.st
@@ -33,6 +33,11 @@ ASLiteral >> asPharoAST [
 	^OCLiteralNode value: literal.
 ]
 
+{ #category : 'comparing' }
+ASLiteral >> hash [
+	^{ self class . self literal } hash
+]
+
 { #category : 'accessing' }
 ASLiteral >> inferType: aClass [
 

--- a/Smalltalk/Zag-Core/ASLiteral.class.st
+++ b/Smalltalk/Zag-Core/ASLiteral.class.st
@@ -25,8 +25,7 @@ ASLiteral >> = other [
 
 { #category : 'visiting' }
 ASLiteral >> accept: aVisitor [
-
-	^ aVisitor visitLiteral: literal
+	^ aVisitor visitLiteral: self
 ]
 
 { #category : 'converting' }

--- a/Smalltalk/Zag-Core/ASMethodNode.class.st
+++ b/Smalltalk/Zag-Core/ASMethodNode.class.st
@@ -59,7 +59,6 @@ ASMethodNode >> = other [
 
 { #category : 'visiting' }
 ASMethodNode >> accept: aVisitor [
-
 	^ aVisitor visitMethod: self
 ]
 

--- a/Smalltalk/Zag-Core/ASPragma.class.st
+++ b/Smalltalk/Zag-Core/ASPragma.class.st
@@ -17,6 +17,11 @@ ASPragma class >> args: pramaArgs [
 	^ASPragma new args: pramaArgs 
 ]
 
+{ #category : 'visiting' }
+ASPragma >> accept: aVisitor [
+	^aVisitor visitPragma: self
+]
+
 { #category : 'accessing' }
 ASPragma >> args: paramaArgs [
 	args := paramaArgs 

--- a/Smalltalk/Zag-Core/ASRef.class.st
+++ b/Smalltalk/Zag-Core/ASRef.class.st
@@ -23,6 +23,11 @@ ASRef >> = other [
 	^ self class = other class and: [ self variable = other variable ]
 ]
 
+{ #category : 'visiting' }
+ASRef >> accept: aVisitor [
+	^aVisitor visitRef: self
+]
+
 { #category : 'converting' }
 ASRef >> asPharoAST [
 	^OCVariableNode named: variable.

--- a/Smalltalk/Zag-Core/ASSend.class.st
+++ b/Smalltalk/Zag-Core/ASSend.class.st
@@ -50,6 +50,18 @@ ASSend >> accept: aVisitor [
 	^aVisitor visitSend: self
 ]
 
+{ #category : 'compiling' }
+ASSend >> argNeedsBrackets: anArg [
+	"Accepts one of my (non-target) arguments, and returns whether or not it needs brackets."
+	(anArg isKindOf: ASStatement) ifFalse: [ ^false ].
+	anArg isASAssign ifTrue: [ ^true ].
+	anArg isASSend ifFalse: [ ^false ].
+	^self
+		ifUnary: [ self error: 'Unary messages have no arguments!' ]
+		ifBinary: [ anArg messageType ~= #unary ]
+		ifKeyword: [ anArg messageType = #keyword ].
+]
+
 { #category : 'parsing' }
 ASSend >> args [
 	^ args
@@ -82,6 +94,17 @@ ASSend >> children [
 	^ childeren
 ]
 
+{ #category : 'parsing' }
+ASSend >> ifUnary: unaryBlock ifBinary: binaryBlock ifKeyword: keywordBlock [
+	"Runs one of the provided blocks based on my type."
+	| myType |
+	myType := self messageType.
+	myType = #unary ifTrue: [ ^unaryBlock value ].
+	myType = #binary ifTrue: [ ^binaryBlock value ].
+	myType = #keyword ifTrue: [ ^keywordBlock value ].
+	self error: 'Invalid message type'
+]
+
 { #category : 'printing' }
 ASSend >> inspectZagASTOn: s [
 
@@ -99,6 +122,16 @@ ASSend >> isASSend [
 { #category : 'parsing' }
 ASSend >> maxDepth [
 	^selector numArgs
+]
+
+{ #category : 'parsing' }
+ASSend >> messageType [
+	"Returns whether or not I am unary, binary or keyword."
+	| selectorString |
+	selectorString := self selector asString.
+	(selectorString includes: $:) ifTrue: [ ^#keyword ].
+	^(selectorString allSatisfy: #isSpecial)
+		ifTrue: [ #binary ] ifFalse: [ #unary ].
 ]
 
 { #category : 'parsing' }
@@ -127,6 +160,18 @@ ASSend >> target [
 { #category : 'parsing' }
 ASSend >> target: expression [
 	target := expression
+]
+
+{ #category : 'compiling' }
+ASSend >> targetNeedsBrackets [
+	"Returns whether or not my target needs to be surrounded by brackets in source code."
+	(self target isKindOf: ASStatement) ifFalse: [ ^false ].
+	self target isASAssign ifTrue: [ ^true ].
+	self target isASSend ifFalse: [ ^false ].
+	^self
+		ifUnary: [ self target messageType ~= #unary ]
+		ifBinary: [ self target messageType = #keyword ]
+		ifKeyword: [ self target messageType = #keyword ].
 ]
 
 { #category : 'compiling' }

--- a/Smalltalk/Zag-Core/ASSend.class.st
+++ b/Smalltalk/Zag-Core/ASSend.class.st
@@ -90,7 +90,7 @@ ASSend >> children [
 	| childeren |
 	childeren := OrderedCollection new.
 	target ifNotNil: [ :t | childeren add: t ].
-	childeren addAll: args.
+	args ifNotNil: [ childeren addAll: args ].
 	^ childeren
 ]
 

--- a/Smalltalk/Zag-Core/ASSend.class.st
+++ b/Smalltalk/Zag-Core/ASSend.class.st
@@ -45,6 +45,11 @@ ASSend >> = other [
 			  self target = other target and: [ self args = other args ] ] ]
 ]
 
+{ #category : 'visiting' }
+ASSend >> accept: aVisitor [
+	^aVisitor visitSend: self
+]
+
 { #category : 'parsing' }
 ASSend >> args [
 	^ args

--- a/Smalltalk/Zag-Core/ASThisContext.class.st
+++ b/Smalltalk/Zag-Core/ASThisContext.class.st
@@ -9,6 +9,11 @@ Class {
 	#tag : 'AST'
 }
 
+{ #category : 'visiting' }
+ASThisContext >> accept: aVisitor [
+	^aVisitor visitThisContext: self
+]
+
 { #category : 'converting' }
 ASThisContext >> asPharoAST [
 	^OCVariableNode thisContextNode.

--- a/Smalltalk/Zag-Core/ASThisProcess.class.st
+++ b/Smalltalk/Zag-Core/ASThisProcess.class.st
@@ -9,6 +9,11 @@ Class {
 	#tag : 'AST'
 }
 
+{ #category : 'visiting' }
+ASThisProcess >> accept: aVisitor [
+	^aVisitor visitThisProcess: self
+]
+
 { #category : 'converting' }
 ASThisProcess >> asPharoAST [
 	^OCVariableNode thisProcessNode.

--- a/Smalltalk/Zag-Core/ManifestZagCore.class.st
+++ b/Smalltalk/Zag-Core/ManifestZagCore.class.st
@@ -158,6 +158,13 @@ ManifestZagCore class >> ruleSendsDifferentSuperRuleV1FalsePositive [
 ]
 
 { #category : 'code-critics' }
+ManifestZagCore class >> ruleSentNotImplementedRuleV1FalsePositive [
+
+	<ignoreForCoverage>
+	^ #(#(#(#RGPackageDefinition #(#'Zag-Core')) #'2026-06-16T17:43:07.562-05:00') )
+]
+
+{ #category : 'code-critics' }
 ManifestZagCore class >> ruleStringConcatenationRuleV1FalsePositive [
 	^ #(#(#(#RGPackageDefinition #(#'Zag-Core')) #'2021-03-28T13:56:56.834147-04:00') )
 ]


### PR DESCRIPTION
This branch implements `accept:` for all subclasses of `AST`.

Now that visitors are fully functional, I have also mostly implemented printing for `ZagSmalltalk`.  You should be able to use Ctrl-P on any Zag AST code to print it without experiencing errors.  I have also fixed a few errors I found with AST inspection, meaning you should no longer experience errors when inspecting/debugging code that includes these classes.