### PR TITLE
Allow ASArray to be converted to Pharo

### DIFF
--- a/Smalltalk/Zag-Core/ASArray.class.st
+++ b/Smalltalk/Zag-Core/ASArray.class.st
@@ -30,7 +30,7 @@ ASArray >> accept: aVisitor [
 
 { #category : 'converting' }
 ASArray >> asPharoAST [
-	self error: 'ASArray seems to be missing instance variables!'.
+	^OCArrayNode statements: (self statements collect: #asPharoAST) 
 ]
 
 { #category : 'printing' }


### PR DESCRIPTION
This is a small fix that allows `ASArray` to be converted to Pharo like the other parts of the AST.  This was not in my original Zag-to-Pharo pull request because I didn't know how to extract the statements from the `ASArray` object, which I think we talked about before, but I figured it out.